### PR TITLE
Update proxy_url output to enable access from other namespaces

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
 output "proxy_url" {
   description = "URL for opensearch-proxy service"
-  value       = "http://${kubernetes_service.proxy.metadata[0].name}:${kubernetes_service.proxy.spec[0].port[0].port}"
+  value       = "http://${kubernetes_service.proxy.metadata[0].name}.${kubernetes_service.proxy.metadata[0].namespace}.svc.cluster.local:${kubernetes_service.proxy.spec[0].port[0].port}"
 }


### PR DESCRIPTION
This changes the URL, for example, from:
http://opensearch-proxy-service-cloud-platform-7ee2c0ee:9200 to
http://opensearch-proxy-service-cloud-platform-7ee2c0ee.hmpps-probation-search-dev.svc.cluster.local:9200

The latter is resolvable outside of the service's namespace.


Also happy to create a separate output for this if preferred, rather than replacing `proxy_url`.