### PR TITLE
chore: pin GitHub Actions to commit hashes for security

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -6,10 +6,10 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         ref: ${{ github.event.pull_request.head.ref }}
-    - uses: terraform-docs/gh-actions@v1.3.0
+    - uses: terraform-docs/gh-actions@aeae0038ed47a547e0c0fca5c059d3335f48fb25 # v1.3.0
       with:
         working-dir: .
         output-file: README.md

--- a/.github/workflows/push-terraform-module-version.yml
+++ b/.github/workflows/push-terraform-module-version.yml
@@ -7,7 +7,7 @@ jobs:
   push-terraform-module-version:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Export LATEST_TAG
         run: |
           echo "LATEST_TAG=$(curl \

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -7,8 +7,8 @@ jobs:
     name: Run Terratest Unit Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: hashicorp/setup-terraform@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: hashicorp/setup-terraform@651471c36a6092792c552e8b1bef71e592b462d8 # v3.1.1
         with:
           terraform_version: 1.2.5
           terraform_wrapper: false

--- a/README.md
+++ b/README.md
@@ -120,8 +120,12 @@ See the [examples/](examples/) folder for more information.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_domain_arn"></a> [domain\_arn](#output\_domain\_arn) | OpenSearch domain ARN |
+| <a name="output_domain_name"></a> [domain\_name](#output\_domain\_name) | OpenSearch domain name |
+| <a name="output_endpoint"></a> [endpoint](#output\_endpoint) | OpenSearch VPC endpoint |
 | <a name="output_irsa_role_arn"></a> [irsa\_role\_arn](#output\_irsa\_role\_arn) | Service account role ARN |
 | <a name="output_proxy_url"></a> [proxy\_url](#output\_proxy\_url) | URL for opensearch-proxy service |
+| <a name="output_service_account_name"></a> [service\_account\_name](#output\_service\_account\_name) | Service account name |
 | <a name="output_snapshot_role_arn"></a> [snapshot\_role\_arn](#output\_snapshot\_role\_arn) | Snapshot role ARN |
 <!-- END_TF_DOCS -->
 


### PR DESCRIPTION
### Description
This PR pins GitHub Actions to commit hashes for security.

### Related Issue
Closes https://github.com/ministryofjustice/cloud-platform-security-issues/issues/91