### PR TITLE
Fix for map value error when `ebs_enabled` not provided

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -170,9 +170,9 @@ resource "aws_opensearch_domain" "this" {
 
   ebs_options {
     ebs_enabled = var.ebs_enabled
-    iops        = var.ebs_enabled ? try(var.ebs_options.value["iops"], 3000) : null      # these are AWS defaults
-    throughput  = var.ebs_enabled ? try(var.ebs_options.value["throughput"], 125) : null # these are AWS defaults
-    volume_size = var.ebs_enabled ? var.ebs_options.value["volume_size"] : null
+    iops        = var.ebs_enabled ? try(var.ebs_options["iops"], 3000) : null      # these are AWS defaults
+    throughput  = var.ebs_enabled ? try(var.ebs_options["throughput"], 125) : null # these are AWS defaults
+    volume_size = var.ebs_enabled ? var.ebs_options["volume_size"] : null
     volume_type = var.ebs_enabled ? "gp3" : null
   }
 


### PR DESCRIPTION
Error: https://concourse.cloud-platform.service.justice.gov.uk/builds/36912177#L682e900f:30
```
Error: Missing map element

  on .terraform/modules/opensearch/main.tf line 175, in resource "aws_opensearch_domain" "this":
 175:     volume_size = var.ebs_enabled ? var.ebs_options.value["volume_size"] : null
    ├────────────────
    │ var.ebs_options is map of number with 3 elements

This map does not have an element with the key "value".
```

Tested fix here: https://concourse.cloud-platform.service.justice.gov.uk/builds/36912417